### PR TITLE
Blacklisting only 'kube.pod.container.resource.limits.*' metrics, not requests.*

### DIFF
--- a/deploy/examples/conf.example.yaml
+++ b/deploy/examples/conf.example.yaml
@@ -30,7 +30,7 @@ data:
         - 'kube.namespace.annotations.gauge'        
         - 'kube.persistentvolume.*'
         - 'kube.persistentvolumeclaim.*'
-        - 'kube.pod.container.resource.*'
+        - 'kube.pod.container.resource.limits.*'
         - 'kube.pod.container.*.reason.gauge'
         - 'kube.pod.labels.gauge'
         - 'kube.pod.owner.gauge'


### PR DESCRIPTION
Minor changes to blacklist only `kube.pod.container.resource.limits.*` metrics, not `kube.pod.container.resource.requests.*`